### PR TITLE
add support for apple m1

### DIFF
--- a/src/webdriver_auto_update.py
+++ b/src/webdriver_auto_update.py
@@ -4,6 +4,7 @@ import subprocess
 import wget
 import zipfile
 import sys
+import platform
 from pathlib import Path
 
 
@@ -85,5 +86,5 @@ def obtain_os():
     elif sys.platform.startswith('linux'):
         os_name='linux64'
     elif sys.platform.startswith('darwin'):
-        os_name='mac64'
+        os_name='mac_arm64' if platform.machine() == 'arm64' else 'mac64'
     return os_name


### PR DESCRIPTION
I noticed I was using the x64 version of chromedriver after installing using the current library on my M1 macbook. It still works (likely through Rosetta emulation) but this small change checks the platform to get the arm version of chromedriver for M1 macs.